### PR TITLE
Add SideMenu component

### DIFF
--- a/SideMenu/SideMenu.xcodeproj/project.pbxproj
+++ b/SideMenu/SideMenu.xcodeproj/project.pbxproj
@@ -1,0 +1,395 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		C7B5DBAC2C98CC1F009CEA27 /* SideMenuApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B5DBAB2C98CC1F009CEA27 /* SideMenuApp.swift */; };
+		C7B5DBAE2C98CC1F009CEA27 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B5DBAD2C98CC1F009CEA27 /* ContentView.swift */; };
+		C7B5DBB02C98CC20009CEA27 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7B5DBAF2C98CC20009CEA27 /* Assets.xcassets */; };
+		C7B5DBB32C98CC20009CEA27 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C7B5DBB22C98CC20009CEA27 /* Preview Assets.xcassets */; };
+		C7B5DBBA2C98CFEA009CEA27 /* SideMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B5DBB92C98CFEA009CEA27 /* SideMenuView.swift */; };
+		C7B5DBBC2C98D9FD009CEA27 /* SideMenuRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B5DBBB2C98D9FD009CEA27 /* SideMenuRowView.swift */; };
+		C7B5DBBE2C98DCAE009CEA27 /* SideMenuOptionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B5DBBD2C98DCAE009CEA27 /* SideMenuOptionModel.swift */; };
+		C7B5DBC02C98F513009CEA27 /* SideMenuHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B5DBBF2C98F513009CEA27 /* SideMenuHeaderView.swift */; };
+		C7B5DBC22C98FC8E009CEA27 /* ColorTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B5DBC12C98FC8E009CEA27 /* ColorTheme.swift */; };
+		C7B5DBC62C990964009CEA27 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B5DBC52C990964009CEA27 /* DetailView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		C7B5DBA82C98CC1F009CEA27 /* SideMenu.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SideMenu.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C7B5DBAB2C98CC1F009CEA27 /* SideMenuApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuApp.swift; sourceTree = "<group>"; };
+		C7B5DBAD2C98CC1F009CEA27 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		C7B5DBAF2C98CC20009CEA27 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		C7B5DBB22C98CC20009CEA27 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		C7B5DBB92C98CFEA009CEA27 /* SideMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuView.swift; sourceTree = "<group>"; };
+		C7B5DBBB2C98D9FD009CEA27 /* SideMenuRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuRowView.swift; sourceTree = "<group>"; };
+		C7B5DBBD2C98DCAE009CEA27 /* SideMenuOptionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuOptionModel.swift; sourceTree = "<group>"; };
+		C7B5DBBF2C98F513009CEA27 /* SideMenuHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuHeaderView.swift; sourceTree = "<group>"; };
+		C7B5DBC12C98FC8E009CEA27 /* ColorTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorTheme.swift; sourceTree = "<group>"; };
+		C7B5DBC52C990964009CEA27 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		C7B5DBA52C98CC1F009CEA27 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		C7B5DB9F2C98CC1F009CEA27 = {
+			isa = PBXGroup;
+			children = (
+				C7B5DBAA2C98CC1F009CEA27 /* SideMenu */,
+				C7B5DBA92C98CC1F009CEA27 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		C7B5DBA92C98CC1F009CEA27 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C7B5DBA82C98CC1F009CEA27 /* SideMenu.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		C7B5DBAA2C98CC1F009CEA27 /* SideMenu */ = {
+			isa = PBXGroup;
+			children = (
+				C7B5DBC92C991337009CEA27 /* Theme */,
+				C7B5DBC82C991324009CEA27 /* Models */,
+				C7B5DBC72C991306009CEA27 /* Views */,
+				C7B5DBAB2C98CC1F009CEA27 /* SideMenuApp.swift */,
+				C7B5DBAF2C98CC20009CEA27 /* Assets.xcassets */,
+				C7B5DBB12C98CC20009CEA27 /* Preview Content */,
+			);
+			path = SideMenu;
+			sourceTree = "<group>";
+		};
+		C7B5DBB12C98CC20009CEA27 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				C7B5DBB22C98CC20009CEA27 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		C7B5DBC72C991306009CEA27 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				C7B5DBAD2C98CC1F009CEA27 /* ContentView.swift */,
+				C7B5DBC52C990964009CEA27 /* DetailView.swift */,
+				C7B5DBB92C98CFEA009CEA27 /* SideMenuView.swift */,
+				C7B5DBBB2C98D9FD009CEA27 /* SideMenuRowView.swift */,
+				C7B5DBBF2C98F513009CEA27 /* SideMenuHeaderView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		C7B5DBC82C991324009CEA27 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				C7B5DBBD2C98DCAE009CEA27 /* SideMenuOptionModel.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		C7B5DBC92C991337009CEA27 /* Theme */ = {
+			isa = PBXGroup;
+			children = (
+				C7B5DBC12C98FC8E009CEA27 /* ColorTheme.swift */,
+			);
+			path = Theme;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		C7B5DBA72C98CC1F009CEA27 /* SideMenu */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C7B5DBB62C98CC20009CEA27 /* Build configuration list for PBXNativeTarget "SideMenu" */;
+			buildPhases = (
+				C7B5DBA42C98CC1F009CEA27 /* Sources */,
+				C7B5DBA52C98CC1F009CEA27 /* Frameworks */,
+				C7B5DBA62C98CC1F009CEA27 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SideMenu;
+			productName = SideMenu;
+			productReference = C7B5DBA82C98CC1F009CEA27 /* SideMenu.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		C7B5DBA02C98CC1F009CEA27 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1520;
+				LastUpgradeCheck = 1520;
+				TargetAttributes = {
+					C7B5DBA72C98CC1F009CEA27 = {
+						CreatedOnToolsVersion = 15.2;
+					};
+				};
+			};
+			buildConfigurationList = C7B5DBA32C98CC1F009CEA27 /* Build configuration list for PBXProject "SideMenu" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = C7B5DB9F2C98CC1F009CEA27;
+			productRefGroup = C7B5DBA92C98CC1F009CEA27 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				C7B5DBA72C98CC1F009CEA27 /* SideMenu */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		C7B5DBA62C98CC1F009CEA27 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C7B5DBB32C98CC20009CEA27 /* Preview Assets.xcassets in Resources */,
+				C7B5DBB02C98CC20009CEA27 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		C7B5DBA42C98CC1F009CEA27 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C7B5DBC22C98FC8E009CEA27 /* ColorTheme.swift in Sources */,
+				C7B5DBC62C990964009CEA27 /* DetailView.swift in Sources */,
+				C7B5DBBA2C98CFEA009CEA27 /* SideMenuView.swift in Sources */,
+				C7B5DBBE2C98DCAE009CEA27 /* SideMenuOptionModel.swift in Sources */,
+				C7B5DBBC2C98D9FD009CEA27 /* SideMenuRowView.swift in Sources */,
+				C7B5DBC02C98F513009CEA27 /* SideMenuHeaderView.swift in Sources */,
+				C7B5DBAE2C98CC1F009CEA27 /* ContentView.swift in Sources */,
+				C7B5DBAC2C98CC1F009CEA27 /* SideMenuApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		C7B5DBB42C98CC20009CEA27 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		C7B5DBB52C98CC20009CEA27 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		C7B5DBB72C98CC20009CEA27 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"SideMenu/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ivansaul.SideMenu;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		C7B5DBB82C98CC20009CEA27 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"SideMenu/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ivansaul.SideMenu;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C7B5DBA32C98CC1F009CEA27 /* Build configuration list for PBXProject "SideMenu" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C7B5DBB42C98CC20009CEA27 /* Debug */,
+				C7B5DBB52C98CC20009CEA27 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C7B5DBB62C98CC20009CEA27 /* Build configuration list for PBXNativeTarget "SideMenu" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C7B5DBB72C98CC20009CEA27 /* Debug */,
+				C7B5DBB82C98CC20009CEA27 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = C7B5DBA02C98CC1F009CEA27 /* Project object */;
+}

--- a/SideMenu/SideMenu.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/SideMenu/SideMenu.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/SideMenu/SideMenu.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SideMenu/SideMenu.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SideMenu/SideMenu/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/SideMenu/SideMenu/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SideMenu/SideMenu/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SideMenu/SideMenu/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SideMenu/SideMenu/Assets.xcassets/ColorTheme/Background/BackgroundColor.colorset/Contents.json
+++ b/SideMenu/SideMenu/Assets.xcassets/ColorTheme/Background/BackgroundColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.169",
+          "green" : "0.114",
+          "red" : "0.122"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SideMenu/SideMenu/Assets.xcassets/ColorTheme/Background/Contents.json
+++ b/SideMenu/SideMenu/Assets.xcassets/ColorTheme/Background/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SideMenu/SideMenu/Assets.xcassets/ColorTheme/Contents.json
+++ b/SideMenu/SideMenu/Assets.xcassets/ColorTheme/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SideMenu/SideMenu/Assets.xcassets/ColorTheme/Primary/Contents.json
+++ b/SideMenu/SideMenu/Assets.xcassets/ColorTheme/Primary/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SideMenu/SideMenu/Assets.xcassets/ColorTheme/Primary/PrimaryColorBlue.colorset/Contents.json
+++ b/SideMenu/SideMenu/Assets.xcassets/ColorTheme/Primary/PrimaryColorBlue.colorset/Contents.json
@@ -1,0 +1,41 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.198",
+          "red" : "0.017"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.198",
+          "red" : "0.017"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "localizable" : true
+  }
+}

--- a/SideMenu/SideMenu/Assets.xcassets/ColorTheme/Text/Contents.json
+++ b/SideMenu/SideMenu/Assets.xcassets/ColorTheme/Text/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SideMenu/SideMenu/Assets.xcassets/ColorTheme/Text/TextColorBlack.colorset/Contents.json
+++ b/SideMenu/SideMenu/Assets.xcassets/ColorTheme/Text/TextColorBlack.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SideMenu/SideMenu/Assets.xcassets/ColorTheme/Text/TextColorWhite.colorset/Contents.json
+++ b/SideMenu/SideMenu/Assets.xcassets/ColorTheme/Text/TextColorWhite.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SideMenu/SideMenu/Assets.xcassets/Contents.json
+++ b/SideMenu/SideMenu/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SideMenu/SideMenu/Models/SideMenuOptionModel.swift
+++ b/SideMenu/SideMenu/Models/SideMenuOptionModel.swift
@@ -1,0 +1,52 @@
+//
+//  SideMenuOptionModel.swift
+//  SideMenu
+//
+//  Created by ivansaul on 9/16/24.
+//
+
+import Foundation
+
+enum SideMenuOptionModel: Int, CaseIterable {
+    case dashboard
+    case performance
+    case profile
+    case search
+    case notifications
+
+    var title: String {
+        switch self {
+        case .dashboard:
+            "Dashboard"
+        case .performance:
+            "Performance"
+        case .profile:
+            "Profile"
+        case .search:
+            "Search"
+        case .notifications:
+            "Notifications"
+        }
+    }
+
+    var systemImageName: String {
+        switch self {
+        case .dashboard:
+            "square.grid.2x2"
+        case .performance:
+            "chart.bar"
+        case .profile:
+            "person"
+        case .search:
+            "magnifyingglass"
+        case .notifications:
+            "bell.badge"
+        }
+    }
+}
+
+extension SideMenuOptionModel: Identifiable {
+    var id: Int {
+        self.rawValue
+    }
+}

--- a/SideMenu/SideMenu/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/SideMenu/SideMenu/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SideMenu/SideMenu/SideMenuApp.swift
+++ b/SideMenu/SideMenu/SideMenuApp.swift
@@ -1,0 +1,17 @@
+//
+//  SideMenuApp.swift
+//  SideMenu
+//
+//  Created by ivansaul on 9/16/24.
+//
+
+import SwiftUI
+
+@main
+struct SideMenuApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/SideMenu/SideMenu/Theme/ColorTheme.swift
+++ b/SideMenu/SideMenu/Theme/ColorTheme.swift
@@ -1,0 +1,25 @@
+//
+//  ColorTheme.swift
+//  SideMenu
+//
+//  Created by ivansaul on 9/16/24.
+//
+
+import Foundation
+import SwiftUI
+
+extension Color {
+    static let theme = ColorTheme()
+}
+
+struct ColorTheme {
+    // BACkGROUND COLO
+    let background = Color("BackgroundColor")
+
+    // PRIMARY COLORS
+    let primaryBlue = Color("PrimaryColorBlue")
+
+    // TEXT COLORS
+    let textBlack = Color("TextColorBlack")
+    let textWhite = Color("TextColorWhite")
+}

--- a/SideMenu/SideMenu/Views/ContentView.swift
+++ b/SideMenu/SideMenu/Views/ContentView.swift
@@ -1,0 +1,43 @@
+//
+//  ContentView.swift
+//  SideMenu
+//
+//  Created by ivansaul on 9/16/24.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    @State private var showMenu: Bool = false
+    @State private var selectedTab: SideMenuOptionModel = .dashboard
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                TabView(selection: $selectedTab) {
+                    ForEach(SideMenuOptionModel.allCases) { option in
+                        DetailView(systemImageName: option.systemImageName)
+                            .tag(option)
+                    }
+                }
+
+                SideMenuView(isShowing: $showMenu, selectedTab: $selectedTab)
+            }
+            .navigationTitle(selectedTab.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar(showMenu ? .hidden : .visible, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(action: {
+                        showMenu.toggle()
+                    }, label: {
+                        Image(systemName: "line.3.horizontal")
+                    })
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/SideMenu/SideMenu/Views/DetailView.swift
+++ b/SideMenu/SideMenu/Views/DetailView.swift
@@ -1,0 +1,26 @@
+//
+//  DetailView.swift
+//  SideMenu
+//
+//  Created by ivansaul on 9/16/24.
+//
+
+import SwiftUI
+
+struct DetailView: View {
+    let systemImageName: String
+    var body: some View {
+        ZStack {
+            // Background Color
+            Color.theme.background
+                .ignoresSafeArea()
+            // Content
+            Image(systemName: systemImageName)
+                .font(.largeTitle)
+        }
+    }
+}
+
+#Preview {
+    DetailView(systemImageName: "paperplane")
+}

--- a/SideMenu/SideMenu/Views/SideMenuHeaderView.swift
+++ b/SideMenu/SideMenu/Views/SideMenuHeaderView.swift
@@ -1,0 +1,34 @@
+//
+//  SideMenuHeaderView.swift
+//  SideMenu
+//
+//  Created by ivansaul on 9/16/24.
+//
+
+import SwiftUI
+
+struct SideMenuHeaderView: View {
+    var body: some View {
+        HStack {
+            Image(systemName: "person.circle.fill")
+                .imageScale(.large)
+                .foregroundStyle(.white)
+                .frame(width: 48, height: 48)
+                .background(.blue)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            VStack(alignment: .leading, spacing: 5.0) {
+                Text("Ivan Saul")
+                    .font(.headline)
+
+                Text("test@swift.com")
+                    .font(.footnote)
+                    .tint(.gray)
+            }
+        }
+    }
+}
+
+#Preview {
+    SideMenuHeaderView()
+}

--- a/SideMenu/SideMenu/Views/SideMenuRowView.swift
+++ b/SideMenu/SideMenu/Views/SideMenuRowView.swift
@@ -1,0 +1,32 @@
+//
+//  SideMenuRowView.swift
+//  SideMenu
+//
+//  Created by ivansaul on 9/16/24.
+//
+
+import SwiftUI
+
+struct SideMenuRowView: View {
+    let title: String
+    let systemImageName: String
+    var isSelected: Bool
+    var body: some View {
+        HStack {
+            Image(systemName: systemImageName)
+                .imageScale(.small)
+            Text(title)
+                .font(.subheadline)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(isSelected ? .blue.opacity(0.2) : .clear)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .padding(.leading)
+        .animation(.easeIn, value: isSelected)
+    }
+}
+
+#Preview {
+    SideMenuRowView(title: "Message", systemImageName: "paperplane", isSelected: true)
+}

--- a/SideMenu/SideMenu/Views/SideMenuView.swift
+++ b/SideMenu/SideMenu/Views/SideMenuView.swift
@@ -1,0 +1,65 @@
+//
+//  SideMenuView.swift
+//  SideMenu
+//
+//  Created by ivansaul on 9/16/24.
+//
+
+import SwiftUI
+
+struct SideMenuView: View {
+    @Binding var isShowing: Bool
+    @Binding var selectedTab: SideMenuOptionModel
+    @State private var selectedOption: SideMenuOptionModel = .dashboard
+    var body: some View {
+        ZStack {
+            if isShowing {
+                Color.gray.opacity(0.3)
+                    .ignoresSafeArea()
+                    .onTapGesture {
+                        isShowing.toggle()
+                    }
+
+                HStack {
+                    VStack(alignment: .leading, spacing: 20.0) {
+                        // Side Menu Header
+                        SideMenuHeaderView()
+                        // Side Menu Options
+                        ForEach(SideMenuOptionModel.allCases) { option in
+                            Button(action: {
+                                onOptionTapped(option)
+                            }, label: {
+                                SideMenuRowView(
+                                    title: option.title,
+                                    systemImageName: option.systemImageName,
+                                    isSelected: selectedOption == option
+                                )
+                            })
+                        }
+
+                        Spacer()
+                    }
+                    .padding()
+                    .frame(width: 270)
+                    .background(Color.theme.background)
+
+                    Spacer()
+                }
+                .transition(.move(edge: .leading))
+            }
+        }
+        .animation(.easeInOut, value: isShowing)
+    }
+}
+
+#Preview {
+    SideMenuView(isShowing: .constant(true), selectedTab: .constant(.profile))
+}
+
+extension SideMenuView {
+    private func onOptionTapped(_ option: SideMenuOptionModel) {
+        selectedOption = option
+        selectedTab = option
+        isShowing = false
+    }
+}


### PR DESCRIPTION
This PR introduces a new SideMenu component as part of the SwiftUI Components collection. The SideMenu example demonstrates basic navigation and layout, intended for reuse in future UI projects.

![Recording-at-2024-09-16-213427](https://github.com/user-attachments/assets/00eb3993-482e-4129-8ec3-7cf792b7f654)
